### PR TITLE
Breadcrumbs for product detail

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,10 +1,16 @@
 import React from "react";
 import "./Header.css";
 import { Col, Container, Row } from "react-grid-system";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import Logo from "./Logo";
+import { useSelector } from "react-redux";
+import { selectProduct } from "../features/product/productSlice";
 
 function Header () {
+    const product = useSelector(selectProduct);
+    const location = useLocation();
+    const isRoot = location.pathname === "/";
+
     return (
         <Container fluid className="header">
             <Row>
@@ -18,6 +24,14 @@ function Header () {
             <Row>
                 <Col className="breadcrumbs">
                     <Link to="/">Home</Link>
+                    {product && !isRoot &&
+                        <>
+                            &nbsp; &gt; &nbsp;
+                            <Link to={`/products/${product.id}`}>
+                                {product.name}
+                            </Link>
+                        </>
+                    }
                 </Col>
             </Row>
         </Container>

--- a/src/features/product/productSlice.js
+++ b/src/features/product/productSlice.js
@@ -37,6 +37,9 @@ const reducers = {
             return matchesName || matchesBinomialName;
         };
         state.filteredProducts = state.products.filter(byNames);
+    },
+    resetProduct: (state) => {
+        state.product = null;
     }
 };
 
@@ -58,7 +61,7 @@ export const productSlice = createSlice({
     extraReducers
 });
 
-export const { filterProducts } = productSlice.actions;
+export const { filterProducts, resetProduct } = productSlice.actions;
 
 export const selectFilteredProducts = state => state.product.filteredProducts;
 export const selectProduct = state => state.product.product;

--- a/src/screens/Products.js
+++ b/src/screens/Products.js
@@ -3,7 +3,7 @@ import "./Products.css";
 import { Col, Container, Row } from "react-grid-system";
 import Item from "../components/Item";
 import { useDispatch, useSelector } from "react-redux";
-import { selectFilteredProducts, getProductsAsync } from "../features/product/productSlice";
+import { selectFilteredProducts, getProductsAsync, resetProduct } from "../features/product/productSlice";
 import Search from "../components/Search";
 
 function Products () {
@@ -12,6 +12,7 @@ function Products () {
 
     useEffect(() => {
         dispatch(getProductsAsync());
+        dispatch(resetProduct());
     }, []);
 
     return (


### PR DESCRIPTION
Adds logic to show detail link in breadcrumbs just in product view.

Also, reseted product object each time we navigate to list, or it'll behave weird when entering a product after loaded another one before.